### PR TITLE
Revert "build(deps-dev): bump html-proofer from 3.19.4 to 5.0.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "jekyll-theme-chirpy", "~> 5.3"
 
 group :test do
-  gem "html-proofer", "~> 5.0"
+  gem "html-proofer", "~> 3.18"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,8 @@ GEM
   specs:
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    async (2.3.0)
-      console (~> 1.10)
-      io-event (~> 1.1)
-      timers (~> 4.1)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
-    console (1.16.2)
-      fiber-local
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -18,20 +12,18 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.15.5)
-    fiber-local (1.0.0)
     forwardable-extended (2.6.0)
-    html-proofer (5.0.3)
+    html-proofer (3.19.4)
       addressable (~> 2.3)
-      async (~> 2.1)
+      mercenary (~> 0.3)
       nokogiri (~> 1.13)
+      parallel (~> 1.10)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-event (1.1.3)
     jekyll (4.3.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -83,10 +75,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.0)
-    racc (1.6.1)
+    racc (1.6.0)
     rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -98,7 +91,6 @@ GEM
       ffi (~> 1.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    timers (4.3.5)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (2.0.5)
@@ -109,7 +101,6 @@ GEM
     wdm (0.1.1)
     webrick (1.7.0)
     yell (2.2.2)
-    zeitwerk (2.6.6)
 
 PLATFORMS
   arm64-darwin-22
@@ -117,7 +108,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  html-proofer (~> 5.0)
+  html-proofer (~> 3.18)
   jekyll-theme-chirpy (~> 5.3)
   tzinfo (~> 2.0)
   tzinfo-data


### PR DESCRIPTION
Reverts HarryVasanth/harryvasanth.github.io#18